### PR TITLE
Add contextual guidance component

### DIFF
--- a/app/assets/javascripts/contextual-guidance.js
+++ b/app/assets/javascripts/contextual-guidance.js
@@ -1,0 +1,41 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function ContextualGuidance () { }
+
+  ContextualGuidance.prototype.start = function ($module) {
+    this.$module = $module
+
+    var fields = document.querySelectorAll(
+      '[data-contextual-guidance="' + this.$module.id + '"]'
+    )
+
+    fields.forEach(function (field) {
+      field.addEventListener('focus', this.handleFocus.bind(this))
+    }, this)
+  }
+
+  ContextualGuidance.prototype.handleFocus = function (event) {
+    this.hideAllGuidance()
+    if (!event.target.dataset.contextualGuidanceHideOnly) {
+      this.$module.style.display = 'block'
+    }
+  }
+
+  ContextualGuidance.prototype.hideAllGuidance = function () {
+    var guidances = document.querySelectorAll('[data-module="contextual-guidance"]')
+
+    guidances.forEach(function (guidance) {
+      guidance.style.display = 'none'
+    })
+  }
+
+  Modules.ContextualGuidance = ContextualGuidance
+})(window.GOVUK.Modules)
+
+var $guidance = document.querySelectorAll('[data-module="contextual-guidance"]')
+$guidance.forEach(function ($guidance) {
+  var $g = new window.GOVUK.Modules.ContextualGuidance()
+  $g.start($guidance)
+})

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -13,6 +13,7 @@ $govuk-global-styles: true;
 @import "components/cookie-banner";
 @import "components/autocomplete";
 @import "components/browse";
+@import "components/contextual-guidance";
 @import "components/miller-columns";
 @import "components/checkbox-small";
 @import "components/modal-dialogue";

--- a/app/assets/sass/components/_contextual-guidance.scss
+++ b/app/assets/sass/components/_contextual-guidance.scss
@@ -1,0 +1,39 @@
+.app-c-contextual-guidance__form {
+  .govuk-grid-column-one-third,
+  .govuk-grid-column-two-thirds {
+    position: relative;
+  }
+
+  .govuk-grid-row:last-of-type .app-c-contextual-guidance__wrapper {
+    position: relative;
+  }
+}
+
+.app-c-contextual-guidance__wrapper {
+  position: relative;
+
+  @include govuk-font(19);
+
+  @include govuk-responsive-margin(6, "bottom");
+
+  @include govuk-media-query($from: tablet) {
+    padding-top: govuk-spacing(6);
+  }
+}
+
+.js-enabled {
+  .app-c-contextual-guidance__wrapper {
+    display: none;
+
+    @include govuk-media-query($from: tablet) {
+      position: absolute;
+      margin-right: govuk-spacing(3);
+    }
+  }
+}
+
+.app-c-contextual-guidance {
+  padding-top: govuk-spacing(5);
+  border-top: 5px solid $govuk-focus-colour;
+  background: govuk-colour("white");
+}

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -4,6 +4,7 @@
 <script src="/public/javascripts/autocomplete.js"></script>
 <script src="/public/javascripts/miller-columns.js"></script>
 <script src="/public/javascripts/modal-dialogue.js"></script>
+<script src="/public/javascripts/contextual-guidance.js"></script>
 <script src="/public/javascripts/application.js"></script>
 
 {% if useAutoStoreData %}


### PR DESCRIPTION
This PR adds the contextual guidance component to be used within the prototype.

## Usage

The contract between an input form field (input, textarea, select, etc) and the associated guidance is done through the guidance id (in the example below labeled as `my-guidance-id`).

- The form must have a `app-c-contextual-guidance__form` class attached to it
- The input must have a `data-contextual-guidance` set with the guidance id.
- The guidance container must have an id (e.g. `my-guidance-id`) and a `data-module="contextual-guidance"`.

### Example
```html
<form class="app-c-contextual-guidance__form">
  <input class="govuk-input" data-contextual-guidance="my-guidance-id" />
  
  <div class="app-c-contextual-guidance__wrapper" id="my-guidance-id" data-module="contextual-guidance">
    <div class="app-c-contextual-guidance">
      <h2 class="govuk-heading-s">Create a news title</h2>
      <p class="govuk-body">The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.</p>
    </div>
  </div>
</form>
```

It's also expected that the input and guidance are laid out in a grid container
```html
<div class="govuk-grid-row">
  <div class="govuk-grid-column-two-thirds">
    [Input goes here]
  </div>
  <div class="govuk-grid-column-one-third">`
    [Guidance goes here]
  </div>
</div>
```
